### PR TITLE
Force archive videos to play inline on mobile

### DIFF
--- a/src/components/Archive.astro
+++ b/src/components/Archive.astro
@@ -109,6 +109,7 @@ for (const asset of assets) {
                   data-src={asset.video.mp4Url}
                   poster={asset.video.thumbnailUrl}
                   muted
+                  playsinline
                   preload="none"
                 />
               </div>


### PR DESCRIPTION
Add playsinline attribute to video elements in Archive.astro so they
don't open fullscreen on iOS/Safari when the hover preview triggers
playback. All other video elements in the codebase already had this
attribute; the archive was the only exception.

https://claude.ai/code/session_01SYNp6AP8wjCYPTKMKShbmF